### PR TITLE
px2-sitemapexcel 2.0.8 release draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ $ chmod -R 777 ./px-files/sitemaps
 
 ## 更新履歴 - Change log
 
-### px2-sitemapexcel 2.0.8 (2017年??月??日)
+### px2-sitemapexcel 2.0.8 (2017年9月14日)
 
 - xlsx->csv 変換時に消費するメモリ量を削減するように修正した。
 - title列のすぐ右の列に値が入っている場合に、エイリアスとして解釈されてしまう不具合を修正。

--- a/php/pickles-sitemap-excel.php
+++ b/php/pickles-sitemap-excel.php
@@ -45,7 +45,7 @@ class pickles_sitemap_excel{
 	 * @return string バージョン番号を示す文字列
 	 */
 	public function get_version(){
-		return '2.0.8-alpha.1+nb';
+		return '2.0.8';
 	}
 
 	/**


### PR DESCRIPTION
- xlsx->csv 変換時に消費するメモリ量を削減するように修正した。
- title列のすぐ右の列に値が入っている場合に、エイリアスとして解釈されてしまう不具合を修正。